### PR TITLE
manifest_sevenbridges: incremented version and added option to save as text file

### DIFF
--- a/generate_manifest_sevenbridges/v1.1/Dockerfile
+++ b/generate_manifest_sevenbridges/v1.1/Dockerfile
@@ -3,7 +3,7 @@ FROM rocker/r-ubuntu:22.04
 LABEL maintainer="David Williams <dnwilliams@rti.org>"
 LABEL description="This Docker image contains an in-house script written to generate a file manifest of projects in Seven Bridges."
 LABEL base-image="rocker/r-ubuntu:22.04"
-LABEL software-version="1.0"
+LABEL software-version="1.1"
 
 # Install vim and required packages for R libraries
 RUN apt update && apt install -y \

--- a/generate_manifest_sevenbridges/v1.1/README.md
+++ b/generate_manifest_sevenbridges/v1.1/README.md
@@ -1,6 +1,6 @@
 # Description
 
-This Docker image contains an in-house script written to create an Excel workbook or tab-separated text file of a file and folder manifest of a Seven Bridges project.  Its purpose is to get a sense of how folders are structured, how much space is used, and how many files exits.  The Input to this should be a Seven Bridges developer's token and a string indicating which project to get a manifest of, and the output is an Excel or text file with a manifest of files and folders of the specified Seven Bridges project.  The following information is provided about the project and its files and folders:
+This Docker image contains an in-house script written to create an Excel workbook **OR** tab-separated text file of a file and folder manifest of a Seven Bridges project.  Its purpose is to get a sense of how folders are structured, how much space is used, and how many files exits.  The Input to this should be a Seven Bridges developer's token and a string indicating which project to get a manifest of, and the output is an Excel **OR** text file with a manifest of files and folders of the specified Seven Bridges project.  The following information is provided about the project and its files and folders:
 
 Summary metrics:
 - Report Date - date manifest was generated
@@ -39,9 +39,9 @@ Usage: convert_ab1_to_fasta.r [OPTIONS]
              -- Required Parameters --
               [-t | --token         ]    <Seven Bridges Developer token> (REQUIRED)
               [-p | --project_id    ]    <Project ID, e.g. "username/test-project"> (REQUIRED)
-             -- Optional Parameters -- 
+             -- Optional Flags -- 
               [-v | --verbose       ]    <Activates verbose mode>
-              [-x | --text_save     ]    <Save output as a text file>
+              [-x | --text_save     ]    <Save output as a tab delimited text file>
              -- Help Flag --  
               [-h | --help          ]    <Displays this help message>
              Example:
@@ -51,7 +51,7 @@ Usage: convert_ab1_to_fasta.r [OPTIONS]
 ## Files included
 
 - `Dockerfile`: the Docker file used to build this image
-- `generate_manifest_sevenbridges.R`: R script that serves as the main executable when the Docker container is run.  Expected behavior is to call the Seven Bridges API recursively on a project and generate an Excel report or tab separated text file containing the project's summary metrics, a directory manifest, and a file manifest.  In the end, this writes the extracted results to an output Excel sheet (.xlsx) or text file (.txt) named after the project's name.
+- `generate_manifest_sevenbridges.R`: R script that serves as the main executable when the Docker container is run.  Expected behavior is to call the Seven Bridges API recursively on a project and generate an Excel report **OR** tab separated text file containing the project's summary metrics, a directory manifest, and a file manifest.  In the end, this writes the extracted results to an output Excel sheet (.xlsx) or text file (.txt) named after the project's name.
 
 ## Contact
 

--- a/generate_manifest_sevenbridges/v1.1/README.md
+++ b/generate_manifest_sevenbridges/v1.1/README.md
@@ -1,6 +1,6 @@
 # Description
 
-This Docker image contains an in-house script written to create an Excel workbook of a file and folder manifest of a Seven Bridges project.  Its purpose is to get a sense of how folders are structured, how much space is used, and how many files exits.  The Input to this should be a Seven Bridges developer's token and a string indicating which project to get a manifest of, and the output is an Excel file with a manifest of files and folders of the specified Seven Bridges project.  The following information is provided about the project and its files and folders:
+This Docker image contains an in-house script written to create an Excel workbook or tab-separated text file of a file and folder manifest of a Seven Bridges project.  Its purpose is to get a sense of how folders are structured, how much space is used, and how many files exits.  The Input to this should be a Seven Bridges developer's token and a string indicating which project to get a manifest of, and the output is an Excel or text file with a manifest of files and folders of the specified Seven Bridges project.  The following information is provided about the project and its files and folders:
 
 Summary metrics:
 - Report Date - date manifest was generated
@@ -25,12 +25,12 @@ Files:
 
 Build
 ```
-docker build -t generate_manifest_sevenbridges:v1 .
+docker build -t generate_manifest_sevenbridges:v1.1 .
 ```
 
 Run
 ```
-docker run -it -v $PWD:/data generate_manifest_sevenbridges:v1 Rscript generate_manifest_sevenbridges.R
+docker run -it -v $PWD:/data generate_manifest_sevenbridges:v1.1 Rscript generate_manifest_sevenbridges.R -t <token-here> -p <project_id-here>
 ```
 
 Usage info:
@@ -41,6 +41,7 @@ Usage: convert_ab1_to_fasta.r [OPTIONS]
               [-p | --project_id    ]    <Project ID, e.g. "username/test-project"> (REQUIRED)
              -- Optional Parameters -- 
               [-v | --verbose       ]    <Activates verbose mode>
+              [-x | --text_save     ]    <Save output as a text file>
              -- Help Flag --  
               [-h | --help          ]    <Displays this help message>
              Example:
@@ -50,7 +51,7 @@ Usage: convert_ab1_to_fasta.r [OPTIONS]
 ## Files included
 
 - `Dockerfile`: the Docker file used to build this image
-- `generate_manifest_sevenbridges.R`: R script that serves as the main executable when the Docker container is run.  Expected behavior is to call the Seven Bridges API recursively on a project and generate an Excel report containing the project's summary metrics, a directory manifest, and a file manifest.  In the end, this writes the extracted results to an output Excel sheet (.xlsx) named after the project's name.
+- `generate_manifest_sevenbridges.R`: R script that serves as the main executable when the Docker container is run.  Expected behavior is to call the Seven Bridges API recursively on a project and generate an Excel report or tab separated text file containing the project's summary metrics, a directory manifest, and a file manifest.  In the end, this writes the extracted results to an output Excel sheet (.xlsx) or text file (.txt) named after the project's name.
 
 ## Contact
 

--- a/generate_manifest_sevenbridges/v1.1/generate_manifest_sevenbridges.R
+++ b/generate_manifest_sevenbridges/v1.1/generate_manifest_sevenbridges.R
@@ -15,9 +15,9 @@ usage <- paste("Usage: convert_ab1_to_fasta.r [OPTIONS]
              -- Required Parameters --
               [-t | --token         ]    <Seven Bridges Developer token> (REQUIRED)
               [-p | --project_id    ]    <Project ID, e.g. \"username/test-project\"> (REQUIRED)
-             -- Optional Parameters -- 
+             -- Optional Flags -- 
               [-v | --verbose       ]    <Activates verbose mode>
-              [-x | --text_save     ]    <Save output as a text file>
+              [-x | --text_save     ]    <Save output as a tab delimited text file>
              -- Help Flag --  
               [-h | --help          ]    <Displays this help message>
              Example:

--- a/generate_manifest_sevenbridges/v1.1/generate_manifest_sevenbridges.R
+++ b/generate_manifest_sevenbridges/v1.1/generate_manifest_sevenbridges.R
@@ -17,6 +17,7 @@ usage <- paste("Usage: convert_ab1_to_fasta.r [OPTIONS]
               [-p | --project_id    ]    <Project ID, e.g. \"username/test-project\"> (REQUIRED)
              -- Optional Parameters -- 
               [-v | --verbose       ]    <Activates verbose mode>
+              [-x | --text_save     ]    <Save output as a text file>
              -- Help Flag --  
               [-h | --help          ]    <Displays this help message>
              Example:
@@ -28,6 +29,7 @@ spec <- matrix(c(
   'token',            't', 1, "character",
   'project_id',       'p', 1, "character",
   'verbose',          'v', 0, "logical",
+  'text_save',        'x', 0, "logical",
   'help',             'h', 0, "logical"
 ), byrow=TRUE, ncol=4);
 
@@ -57,7 +59,14 @@ if (exitFlag) {
   q(save="no",status=1,runLast=FALSE)
 }
 
-print_verbose <- function(x) {if (args$verbose) {print(x)}}
+print_verbose <- function(x) {if ("verbose" %in% names(args)) {print(x)}}
+text_save_flag <- FALSE
+text_save_flag <- "text_save" %in% names(args)
+if (text_save_flag) {
+  print_verbose("text_save_flag set to TRUE - manifest will be saved as text file")
+} else {
+  print_verbose("text_save_flag set to FALSE - manifest will be saved as Excel workbook")
+}
 
 # Extracting inputs
 token <- args$token
@@ -265,7 +274,8 @@ names(summary_metrics_df) <- names(summary_metrics_init)
 summary_metrics <- bind_rows(summary_metrics_init,summary_metrics_df)
 
 df_file_manifest <- df_files %>%
-  mutate(size = size*byte_to_gigabyte) %>%
+  mutate(size = size*byte_to_gigabyte,
+         upload_date = format(upload_date, "%Y-%m-%d %H:%M")) %>%
   filter(type=="file") %>%
   select(`File Name` = name, `File Size (GB)` = size, `Upload Date` = upload_date, `Path` = path, `SB URI` = sb_uri) %>%
   arrange(`File Name`)
@@ -281,28 +291,39 @@ hs2 <- createStyle(halign = "left", textDecoration = "Bold")
 hs3 <- createStyle(halign = "left", textDecoration = c("Bold","underline"))
 hs4 <- createStyle(halign = "left", indent = 1)
 
-# write_sheet <- "test_RMIP_inventory"
 write_sheet <- gsub("^.*\\/","",project_id)
 
-# Creating the workbook and worksheet
-print_verbose(paste0("Writing to workbook: ", write_sheet))
-wb <- createWorkbook()
-addWorksheet(wb, sheetName = write_sheet)
+if (text_save_flag) {
+  write_sheet_text <- paste0(Sys.Date(), "_", write_sheet)
+  cat("Summary Metrics", file = paste0(write_sheet_text,".txt"), append = TRUE, sep = '\n')
+  cat(paste0(colnames(summary_metrics),collapse = '\t'), file = paste0(write_sheet_text,".txt"), append = TRUE, sep = '\n')
+  cat(apply(summary_metrics,1,paste0, collapse = '\t'), file = paste0(write_sheet_text,".txt"), append = TRUE, sep = '\n')
+  cat(paste0(colnames(df_directory_file_counts[,1:3]), collapse = '\t'), file = paste0(write_sheet_text,".txt"), append = TRUE, sep = '\n')
+  cat(apply(df_directory_file_counts[,1:3], 1, paste0, collapse = '\t'), file = paste0(write_sheet_text,".txt"), append = TRUE, sep = '\n')
+  cat("\n\nFile Manifest", file = paste0(write_sheet_text,".txt"), append = TRUE, sep = '\n')
+  cat(paste0(colnames(df_file_manifest), collapse = '\t'), file = paste0(write_sheet_text,".txt"), append = TRUE, sep = '\n')
+  cat(apply(df_file_manifest, 1, paste0, collapse = '\t'), file = paste0(write_sheet_text,".txt"), append = TRUE, sep = '\n')
+} else {
+  # Creating the workbook and worksheet
+  print_verbose(paste0("Writing to workbook: ", write_sheet))
+  wb <- createWorkbook()
+  addWorksheet(wb, sheetName = write_sheet)
 
-# Adding headers and data
-writeData(wb, sheet = write_sheet,x = "Summary Metrics", startRow = 1, headerStyle = hs1)
-mergeCells(wb, sheet= write_sheet, cols=1:5, rows=1)
-addStyle(wb, sheet = write_sheet, cols=1:5, rows=1, style = hs1)
-writeData(wb, sheet = write_sheet,x = summary_metrics, startCol = 1, startRow = 2, colNames = FALSE, rowNames = FALSE)
-writeData(wb, sheet = write_sheet,x = df_directory_file_counts[,1:3], startCol = 1, startRow = 2 + nrow(summary_metrics), colNames = FALSE, rowNames = FALSE )
-writeData(wb, sheet = write_sheet,x = "File Manifest", startCol = 1, startRow = 2 + nrow(summary_metrics) + nrow(df_directory_file_counts) + 1, headerStyle = hs1)
-mergeCells(wb, sheet = write_sheet, cols=1:5, rows=2 + nrow(summary_metrics) + nrow(df_directory_file_counts) + 1)
-addStyle(wb, sheet = write_sheet, cols=1, rows=1 + nrow(summary_metrics) + 1, style = hs3)
-addStyle(wb, sheet = write_sheet, cols=1, rows=1 + nrow(summary_metrics) + depth_one_indexes, style = hs2)
-addStyle(wb, sheet = write_sheet, cols=1, rows=1 + nrow(summary_metrics) + depth_two_plus_indexes, style = hs4)
-addStyle(wb, sheet = write_sheet, cols=1:5, rows=2 + nrow(summary_metrics) + nrow(df_directory_file_counts) + 1, style = hs1)
-writeData(wb, sheet = write_sheet,x = df_file_manifest, startCol = 1, startRow = 2 + nrow(summary_metrics) + nrow(df_directory_file_counts) + 2, headerStyle = hs2)
-setColWidths(wb, sheet = write_sheet, cols = 1:5, widths = c("30","25","25","25","25"))
+  # Adding headers and data
+  writeData(wb, sheet = write_sheet,x = "Summary Metrics", startRow = 1, headerStyle = hs1)
+  mergeCells(wb, sheet= write_sheet, cols=1:5, rows=1)
+  addStyle(wb, sheet = write_sheet, cols=1:5, rows=1, style = hs1)
+  writeData(wb, sheet = write_sheet,x = summary_metrics, startCol = 1, startRow = 2, colNames = FALSE, rowNames = FALSE)
+  writeData(wb, sheet = write_sheet,x = df_directory_file_counts[,1:3], startCol = 1, startRow = 2 + nrow(summary_metrics), colNames = FALSE, rowNames = FALSE )
+  writeData(wb, sheet = write_sheet,x = "File Manifest", startCol = 1, startRow = 2 + nrow(summary_metrics) + nrow(df_directory_file_counts) + 1, headerStyle = hs1)
+  mergeCells(wb, sheet = write_sheet, cols=1:5, rows=2 + nrow(summary_metrics) + nrow(df_directory_file_counts) + 1)
+  addStyle(wb, sheet = write_sheet, cols=1, rows=1 + nrow(summary_metrics) + 1, style = hs3)
+  addStyle(wb, sheet = write_sheet, cols=1, rows=1 + nrow(summary_metrics) + depth_one_indexes, style = hs2)
+  addStyle(wb, sheet = write_sheet, cols=1, rows=1 + nrow(summary_metrics) + depth_two_plus_indexes, style = hs4)
+  addStyle(wb, sheet = write_sheet, cols=1:5, rows=2 + nrow(summary_metrics) + nrow(df_directory_file_counts) + 1, style = hs1)
+  writeData(wb, sheet = write_sheet,x = df_file_manifest, startCol = 1, startRow = 2 + nrow(summary_metrics) + nrow(df_directory_file_counts) + 2, headerStyle = hs2)
+  setColWidths(wb, sheet = write_sheet, cols = 1:5, widths = c("30","25","25","25","25"))
 
-# Saving workbook
-saveWorkbook(wb, paste0(write_sheet,".xlsx"),overwrite = TRUE)
+  # Saving workbook
+  saveWorkbook(wb, paste0(Sys.Date(), "_", write_sheet,".xlsx"),overwrite = TRUE)
+}


### PR DESCRIPTION
# Description
The Seven Bridges file manifest generator originally created an Excel file for developers to use to get a sense of how many and what files a project repository has, but this file can't be viewed in Seven Bridges.  This PR addresses that by adding a toggle to save the manifest as a text file instead of Excel file.

<br>


### Dockerfile Structure and Organization:
- [ ] Does the Dockerfile build?
- [ ] Is tool organized according to [Repository Structure](https://github.com/RTIInternational/biocloud_docker_tools/blob/master/README.md#repository-structure)? 
- [ ] Specific base image with a version tag, e.g., `FROM ubuntu:20.04` instead of `FROM ubuntu`.
- [ ] Add comments to describe each Dockerfile step.

<br>

### Metadata
Include the following LABELs:
- [ ] `LABEL maintainer="Your Name <your.email@rti.org>"`
- [ ] `LABEL base-image="ubuntu:22.04"`
- [ ] `LABEL description="Short description of the purpose of this image"`
- [ ] `LABEL software-website="https://example.com"`
- [ ] `LABEL software-version="1.0.0"`
- [ ] `LABEL license="https://www.example.com/legal/end-user-software-license-agreement"`

<br>

### File and Resource Management:
- [ ] Store scripts, files, and software tools ONLY in `/opt`. 
- [ ] Removing tar files after extraction and delete temporary files and caches generated during the build process.
- [ ] Ensure sensitive data (e.g., API keys, passwords) is not hardcoded in the Dockerfile.

<br>

### Container Behavior 
- [ ] Specify a meaningful `CMD` to define how the container should run by default (help message is a good default).
